### PR TITLE
Rate limiting for JWPlayer and cli tool

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -118,7 +118,7 @@ function requestCommand(args) {
 
 	if (repeat) {
 		const promises = [];
-		for (let i = 0; i < 61; i++) {
+		for (let i = 0; i < 120; i++) {
 			promises.push(
 				client[method](params).then(res => {
 					if (res.status === 'ok') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -106,19 +106,6 @@ class Client {
 	// args.apiKey
 	// args.secretKey
 	makeRequest(args) {
-		// If we've had a request rejected because of rate limiting, we block here
-		// until our blocker has been lifted after a timeout.
-		if (this.rateLimitBlocked) {
-			this.sendBusEvent(
-				{level: 'warn'},
-				{message: 'attempted a request while JWPlayer rate limit blocking in effect'}
-			);
-
-			return Promise.reject(new Error(
-				`Request for ${args.path} has been blocked by the Oddworks JWPLayer client for rate limiting`
-			));
-		}
-
 		const method = 'GET';
 		const path = args.path;
 
@@ -152,51 +139,13 @@ class Client {
 
 		debug(`Making JWPlayer Request - url: ${url}`);
 		debug(' with querystring %o', qs);
-		return Client.request({method, url, qs}).catch(err => {
-			if (err.code === 'JWPLAYER_RATE_LIMIT') {
-				this.setRateLimitBlocker(err.data);
-				return Promise.reject(new Error('JWPlayer api limit exceeded'));
-			}
-		});
+		return Client.request({method, url, qs});
 	}
 
 	isAuthenticated() {
 		const hasApiKey = this.apiKey && typeof this.apiKey === 'string';
 		const hasSecretKey = this.secretKey && typeof this.secretKey === 'string';
 		return hasApiKey && hasSecretKey;
-	}
-
-	setRateLimitBlocker(res) {
-		// JWPLayer rate limited response
-		// {
-		// 	"status": "error",
-		// 	"message": "API account rate limit exceeded.",
-		// 	"code": "RateLimitExceeded",
-		// 	"rate_limit": {
-		// 		"reset": 1482575700,
-		// 		"limit": 60,
-		// 		"remaining": 0
-		// 	},
-		// 	"title": "Rate Limit Exceeded"
-		// }
-		this.rateLimitBlocked = true;
-
-		const now = new Date();
-		const unixNow = Math.ceil(now.getTime() / 1000);
-		let resetSec = res.rate_limit.reset - unixNow;
-		if (isNaN(resetSec)) {
-			resetSec = 61;
-		}
-
-		if (resetSec < 0) {
-			resetSec = 61;
-		}
-
-		console.log(`Rate limit timeout set for ${resetSec} sec.`);
-		setTimeout(() => {
-			this.rateLimitBlocked = false;
-			this.sendBusEvent({level: 'info'}, {message: 'JWPlayer rate limit block has been lifted'});
-		}, (resetSec + 1) * 1000);
 	}
 
 	static request(params) {
@@ -233,7 +182,7 @@ class Client {
 
 				if (res.statusCode === 429) {
 					debug(`JWPLayer has rate limited this application`);
-					const err = new Error(`JWPlayer has rate limited this application`);
+					const err = new Error(`JWPlayer has rate limited this application.`);
 					err.code = 'JWPLAYER_RATE_LIMIT';
 					err.data = data;
 					return reject(err);

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,12 @@ class Client {
 		this.getVideo = this.getVideo.bind(this);
 	}
 
+	sendBusEvent(pattern, event) {
+		if (this.bus) {
+			this.bus.broadcast(pattern, event);
+		}
+	}
+
 	// args.apiKey
 	// args.secretKey
 	getPlaylists(args) {
@@ -100,6 +106,19 @@ class Client {
 	// args.apiKey
 	// args.secretKey
 	makeRequest(args) {
+		// If we've had a request rejected because of rate limiting, we block here
+		// until our blocker has been lifted after a timeout.
+		if (this.rateLimitBlocked) {
+			this.sendBusEvent(
+				{level: 'warn'},
+				{message: 'attempted a request while JWPlayer rate limit blocking in effect'}
+			);
+
+			return Promise.reject(new Error(
+				`Request for ${args.path} has been blocked by the Oddworks JWPLayer client for rate limiting`
+			));
+		}
+
 		const method = 'GET';
 		const path = args.path;
 
@@ -133,13 +152,51 @@ class Client {
 
 		debug(`Making JWPlayer Request - url: ${url}`);
 		debug(' with querystring %o', qs);
-		return Client.request({method, url, qs});
+		return Client.request({method, url, qs}).catch(err => {
+			if (err.code === 'JWPLAYER_RATE_LIMIT') {
+				this.setRateLimitBlocker(err.data);
+				return Promise.reject(new Error('JWPlayer api limit exceeded'));
+			}
+		});
 	}
 
 	isAuthenticated() {
 		const hasApiKey = this.apiKey && typeof this.apiKey === 'string';
 		const hasSecretKey = this.secretKey && typeof this.secretKey === 'string';
 		return hasApiKey && hasSecretKey;
+	}
+
+	setRateLimitBlocker(res) {
+		// JWPLayer rate limited response
+		// {
+		// 	"status": "error",
+		// 	"message": "API account rate limit exceeded.",
+		// 	"code": "RateLimitExceeded",
+		// 	"rate_limit": {
+		// 		"reset": 1482575700,
+		// 		"limit": 60,
+		// 		"remaining": 0
+		// 	},
+		// 	"title": "Rate Limit Exceeded"
+		// }
+		this.rateLimitBlocked = true;
+
+		const now = new Date();
+		const unixNow = Math.ceil(now.getTime() / 1000);
+		let resetSec = res.rate_limit.reset - unixNow;
+		if (isNaN(resetSec)) {
+			resetSec = 61;
+		}
+
+		if (resetSec < 0) {
+			resetSec = 61;
+		}
+
+		console.log(`Rate limit timeout set for ${resetSec} sec.`);
+		setTimeout(() => {
+			this.rateLimitBlocked = false;
+			this.sendBusEvent({level: 'info'}, {message: 'JWPlayer rate limit block has been lifted'});
+		}, (resetSec + 1) * 1000);
 	}
 
 	static request(params) {
@@ -158,7 +215,7 @@ class Client {
 				let data = {};
 				if (isJson && typeof body === 'string') {
 					try {
-						data = resolve(JSON.parse(body));
+						data = JSON.parse(body);
 					} catch (err) {
 						return reject(new Error(
 							`jwplayer client JSON parsing error: ${err.message}`
@@ -172,6 +229,14 @@ class Client {
 					return reject(new Error(
 						'jwplayer client expects content-type to be application/json'
 					));
+				}
+
+				if (res.statusCode === 429) {
+					debug(`JWPLayer has rate limited this application`);
+					const err = new Error(`JWPlayer has rate limited this application`);
+					err.code = 'JWPLAYER_RATE_LIMIT';
+					err.data = data;
+					return reject(err);
 				}
 
 				if (res.statusCode !== 200) {


### PR DESCRIPTION
- adds a --repeat option to the cli tool to max out the api limit.
- handles a maxed out api limit by setting a timeout for a time sent back by the jwplatform api