### PR TITLE
Fix secrets

### DIFF
--- a/lib/default-video-transform.js
+++ b/lib/default-video-transform.js
@@ -23,7 +23,7 @@ module.exports = function defaultAssetTransform(args) {
 		images.push({
 			url: `http://content.jwplatform.com/thumbs/${video.mediaid}-${width}.jpg`,
 			width,
-			mimeType: 'images/jpeg'
+			mimeType: 'image/jpeg'
 		});
 		return width;
 	});

--- a/lib/fetch-jwplayer-playlist.js
+++ b/lib/fetch-jwplayer-playlist.js
@@ -6,7 +6,7 @@ module.exports = function (bus, client, transform) {
 	return function fetchChannelCollection(args) {
 		const spec = args.spec;
 		const channel = args.channel;
-		const secrets = (args.channel.secrets || {}).jwPlatform || {};
+		const secrets = (args.channel.secrets || {}).jwplayer || {};
 		const playlistId = args.spec.playlist.key || args.spec.playlist.id;
 		let collection;
 		let videos;

--- a/lib/fetch-jwplayer-video.js
+++ b/lib/fetch-jwplayer-video.js
@@ -5,7 +5,7 @@ const debug = require('debug')('oddworks:provider:jwplayer:fetch-jwplayer-video'
 
 module.exports = function (bus, client, transform) {
 	return function fetchVideo(args) {
-		const secrets = (args.channel.secrets || {}).jwPlatform || {};
+		const secrets = (args.channel.secrets || {}).jwplayer || {};
 		const spec = args.spec;
 		const videoId = args.spec.video.mediaid || args.spec.video.id;
 
@@ -25,6 +25,7 @@ module.exports = function (bus, client, transform) {
 					if (sources.length === 0) {
 						debug(`No sources found for JWPlayer Video with mediaid of: ${video.mediaid}`);
 					}
+					video.id = video.mediaid;
 
 					return transform({
 						spec,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,6 +91,8 @@ exports.containerFromSource = source => {
 		container = 'mp3';
 	} else if (file.indexOf(`.mp4`) > -1) {
 		container = 'mp4';
+	} else if (file.indexOf(`.m4a`) > -1) {
+		container = 'mp4';
 	}
 
 	return container;

--- a/test/container-from-source-test.js
+++ b/test/container-from-source-test.js
@@ -10,7 +10,7 @@ const correctResponses = [
 	'mp4',
 	'mp4',
 	'mp4',
-	''
+	'mp4'
 ];
 
 let testResponses = [];


### PR DESCRIPTION
Contains:
- fix for secrets param name from `jwPlatform` to `jwplayer`
- gives `.m4a` a container of `mp4`

If accepted please merge, and bump version on npm.